### PR TITLE
Fixed wrong path for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,8 @@
   ],
   "description": "Simple Hierarchical Javascript Routing",
   "main": [
-    "releases/finch.js",
-    "releases/finch.min.js"
+    "finch.js",
+    "finch.min.js"
   ],
   "keywords": [
     "Javascript",


### PR DESCRIPTION
With release bower searches in the folder release for the js files. But they are in the root.
