### PR TITLE
=BG= .min.js not in main for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,7 @@
   ],
   "description": "Simple Hierarchical Javascript Routing",
   "main": [
-    "finch.js",
-    "finch.min.js"
+    "finch.js"
   ],
   "keywords": [
     "Javascript",


### PR DESCRIPTION
convention is to not have the minified file as part of the `main` definition. This would cause users of `bower-main-files` in their app build process to include both, which will result in bloated `vendor.js`, and could lead to indeterminate behaviour.
