### PR TITLE
Use slug for "name" in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Finch JS",
+  "name": "finchjs",
   "version": "0.5.14",
   "homepage": "https://github.com/stoodder/finchjs",
   "authors": [


### PR DESCRIPTION
As explained in https://github.com/bower/bower.json-spec.

I actually stumbled upon the bower.json file when I tried installing the library on Bower and seeing that there's still the old "main" with the .min.js file included in and both files pointing on the /releases directory. Weird how in here it's completely fine.
